### PR TITLE
Replace deprecated `pycrypto` with `pycryptodome` for better security and compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ imageio-ffmpeg==0.6.0
 matplotlib==3.10.1
 biplist==1.0.3
 tk
-pycrypto
+pycryptodome==3.22.0


### PR DESCRIPTION
### 변경 사항
- 보안 및 유지보수 이슈로 더 이상 사용되지 않는 `pycrypto` 대신 `pycryptodome`으로 교체했습니다.
- 기존 `pycrypto`와 API 호환성이 높아 코드 수정 없이 대체 가능하며, 설치 및 사용 시 충돌 방지를 위해 `pycrypto`는 제거하였습니다.

### 이유
- `pycrypto`는 유지보수가 중단되었으며, 알려진 보안 취약점이 존재합니다.
- `pycryptodome`은 활발히 개발 중이며 최신 알고리즘과 보안 패치를 제공하므로 대체가 권장됩니다.

### 영향
- 동일한 API를 사용하므로 기존 기능에 영향을 주지 않습니다.
- `pycrypto` 관련 설치 오류 및 충돌 문제가 해결됩니다.

### 설치 안내
```bash
pip uninstall pycrypto
pip install pycryptodome